### PR TITLE
Add Config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO := $(shell which go)
 
 .PHONY: build
 build:
-	$(GO) build -ldflags "-X github.com/optable/optable-pair-cli/pkg/cli.version=${BUILD_VERSION}" -o bin/pair pkg/cmd/main.go
+	$(GO) build -ldflags="-X 'optable-pair-cli/pkg/cmd/cli.version=${BUILD_VERSION}'" -o bin/pair pkg/cmd/main.go
 
 .PHONY: release
 release: darwin linux windows

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module optable-pair-cli
 go 1.23.0
 
 require (
+	github.com/adrg/xdg v0.5.0
 	github.com/alecthomas/kong v1.2.1
 	github.com/rs/zerolog v1.33.0
 )
@@ -10,5 +11,5 @@ require (
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/sys v0.22.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrg/xdg v0.5.0 h1:dDaZvhMXatArP1NPHhnfaQUqWBLBsmx1h1HXQdMoFCY=
+github.com/adrg/xdg v0.5.0/go.mod h1:dDdY4M4DF9Rjy4kHPeNL+ilVF+p2lK8IdM9/rTSGcI4=
 github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
 github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.2.1 h1:E8jH4Tsgv6wCRX2nGrdPyHDUCSG83WH2qE4XLACD33Q=
@@ -5,6 +7,8 @@ github.com/alecthomas/kong v1.2.1/go.mod h1:rKTSFhbdp3Ryefn8x5MOEprnRFQ7nlmMC01G
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
@@ -14,10 +18,17 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cmd/cli/base.go
+++ b/pkg/cmd/cli/base.go
@@ -10,6 +10,7 @@ import (
 type CliContext struct {
 	ctx     context.Context
 	Timeout time.Duration
+	config  *Config
 }
 
 type Cli struct {
@@ -20,10 +21,11 @@ type Cli struct {
 	Token   string     `placeholder:"<token>" help:"Optable Auth Token"`
 }
 
-func (c *Cli) NewContext() (*CliContext, error) {
+func (c *Cli) NewContext(conf *Config) (*CliContext, error) {
 	cliCtx := &CliContext{
 		ctx:     NewLogger("pair", c.Verbose).WithContext(context.Background()),
 		Timeout: c.Timeout,
+		config:  conf,
 	}
 
 	return cliCtx, nil

--- a/pkg/cmd/cli/config.go
+++ b/pkg/cmd/cli/config.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	// Path to the configuration file.
+	configPath string
+	// Key configuration.
+	keyConfig *KeyConfig
+}
+
+type KeyConfig struct {
+	// Unique identifier for the key.
+	ID string `json:"id"`
+	// base64 encoded key data
+	Key string `json:"key"`
+	// Key is created using which PAIR mode
+	Mode string `json:"mode"`
+	// timestamp of when the key was created
+	// RFC3339 format
+	// e.g. 2021-09-01T12:00:00Z
+	CreatedAt string `json:"created_at"`
+}
+
+func ensureKeyConfigPath(configPath string) error {
+	dir := filepath.Dir(configPath)
+
+	// 0700: rwx------, owner can read, write, execute, but not group or other users.
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("os.MkdirAll(%s): %w", dir, err)
+	}
+
+	return nil
+}
+
+func LoadKeyConfig(configPath string) (*Config, error) {
+	if err := ensureKeyConfigPath(configPath); err != nil {
+		return nil, err
+	}
+
+	// 0600: rw-------, only owner can read and write, but not execute.
+	file, err := os.OpenFile(configPath, os.O_CREATE, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("os.OpenFile: %w", err)
+	}
+	defer file.Close()
+
+	var config KeyConfig
+	if err := json.NewDecoder(file).Decode(&config); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("json.Decode: %w", err)
+		}
+	}
+
+	return &Config{
+		configPath: configPath,
+		keyConfig:  &config,
+	}, nil
+}
+
+func (c *CliContext) SaveCconfig() error {
+	file, err := os.OpenFile(c.config.configPath, os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return fmt.Errorf("os.OpenFile: %w", err)
+	}
+	defer file.Close()
+
+	if err := json.NewEncoder(file).Encode(c.config.keyConfig); err != nil {
+		return fmt.Errorf("json.Encode: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/cli/version.go
+++ b/pkg/cmd/cli/version.go
@@ -1,8 +1,9 @@
 package cli
 
-import "fmt"
+import (
+	"fmt"
+)
 
-// version will be set to be the latest git tag through build flag"
 var version string
 
 type (

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"optable-pair-cli/pkg/cmd/cli"
 
+	"github.com/adrg/xdg"
 	"github.com/alecthomas/kong"
 )
 
@@ -17,6 +18,8 @@ the publisher data clean room operator.
 For more details on how a PAIR clean room operation works, see https://github.com/Optable/match/blob/main/pkg/pair/README.md
 and https://iabtechlab.com/pair/.
 `
+
+const keyConfigPath = "pair/key/key.json"
 
 func main() {
 	var c cli.Cli
@@ -33,7 +36,17 @@ func main() {
 		},
 	)
 
-	cliCtx, err := c.NewContext()
+	configPath, err := xdg.ConfigFile(keyConfigPath)
+	if err != nil {
+		kongCtx.FatalIfErrorf(err)
+	}
+
+	conf, err := cli.LoadKeyConfig(configPath)
+	if err != nil {
+		kongCtx.FatalIfErrorf(err)
+	}
+
+	cliCtx, err := c.NewContext(conf)
 	kongCtx.FatalIfErrorf(err)
 
 	kongCtx.FatalIfErrorf(kongCtx.Run(cliCtx))


### PR DESCRIPTION
This adds Config which creates the directory with `0700` permission and the `key.json` file with `0600` permission.

It also fixes the `version` command. For future references, to find the ldflag -X argument use, `go tool nm ${binary} | grep 
${var}`