### PR TITLE
Add decrypt command

### DIFF
--- a/pkg/cmd/cli/base.go
+++ b/pkg/cmd/cli/base.go
@@ -23,16 +23,7 @@ type Cli struct {
 	ReEncrypt   ReEncryptCmd   `cmd:"" hidden:"" help:"Re-encrypt publisher's PAIR IDs with the advertiser key."`
 	Match       MatchCmd       `cmd:"" help:"Match publisher's PAIR IDs with advertiser's PAIR IDs."`
 	Run         RunCmd         `cmd:"" help:"Run the PAIR clean room operation."`
-}
-
-func (c *MatchCmd) Help() string {
-	return `
-This operation produces the match rate of this PAIR clean room operation,
-and output the list of decrypted and matched PAIR IDs.
-
-Please be aware that this operation is for demo purposes only for
-resonable data size.
-`
+	Decrypt     DecryptCmd     `cmd:"" help:"Decrypt the triple encrypted PAIR IDs using the advertiser private key."`
 }
 
 func (c *Cli) NewContext(conf *Config) (*CliContext, error) {

--- a/pkg/cmd/cli/decrypt.go
+++ b/pkg/cmd/cli/decrypt.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"optable-pair-cli/pkg/io"
+	"optable-pair-cli/pkg/pair"
+)
+
+type (
+	DecryptCmd struct {
+		Input         string `cmd:"" short:"i" help:"The input file containing the matched triple encrypted PAIR IDs to be decrypted. If given a directory, all files in the directory will be processed."`
+		AdvertiserKey string `cmd:"" short:"k" help:"The advertiser private key to use for the operation. If not provided, the key saved in the cofinguration file will be used."`
+		Output        string `cmd:"" short:"o" help:"The output file to write the decrypted PAIR IDs to, default to stdout."`
+		NumThreads    int    `cmd:"" short:"n" default:"1" help:"The number of threads to use for the operation. Default to 1, and maximum is 8."`
+	}
+)
+
+func (c *DecryptCmd) Run(cli *CliContext) error {
+	ctx := cli.Context()
+
+	if c.AdvertiserKey == "" {
+		c.AdvertiserKey = cli.config.keyConfig.Key
+		if c.AdvertiserKey == "" {
+			return errors.New("advertiser key is required, please either provide one or generate one.")
+		}
+	}
+
+	fs, err := io.FileReaders(c.Input)
+	if err != nil {
+		return fmt.Errorf("io.FileReaders: %w", err)
+	}
+	in := io.MultiReader(fs...)
+
+	out, err := io.FileWriter(c.Output)
+	if err != nil {
+		return fmt.Errorf("io.FileWriter: %w", err)
+	}
+
+	d, err := pair.NewPAIRIDReadWriter(in, out)
+	if err != nil {
+		return fmt.Errorf("pair.NewDecrypter: %w", err)
+	}
+
+	// no need for original salt
+	salt := base64.StdEncoding.EncodeToString(make([]byte, 32))
+
+	// Decrypt and write
+	if err := d.Decrypt(ctx, c.NumThreads, salt, c.AdvertiserKey); err != nil {
+		return fmt.Errorf("pair.Decrypt: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/cmd/cli/match.go
+++ b/pkg/cmd/cli/match.go
@@ -11,13 +11,23 @@ import (
 type (
 	MatchCmd struct {
 		PairCleanroomToken string `arg:"" help:"The PAIR clean room token to use for the operation."`
-		AdvertiserInput    string `cmd:"" short:"a" help:"The GCS bucket URL containing objects of advertiser's triple encrypted PAIR IDs. If given a file path, it will read from the file instead. If not provided, it will read from stdin."`
-		PublisherInput     string `cmd:"" short:"p" help:"The GCS bucket URL containing objects of publisher's triple encrypted PAIR IDs. If given a file path, it will read from the file instead. If not provided, it will read from stdin."`
+		AdvertiserInput    string `cmd:"" short:"a" help:"If given a file path, it will read from the file. If not provided, it will read from the GCS path specified from the token."`
+		PublisherInput     string `cmd:"" short:"p" help:"If given a file path, it will read from the file. If not provided, it will read from the GCS path specified from the token."`
 		Output             string `cmd:"" short:"o" help:"The file path to write the decrypted and matched double encrypted PAIR IDs. If given a directory, the output will be files each containing up to 1 million IDs, if given a file, it will contain all the IDs. If none are provided, it will write to stdout."`
 		AdvertiserKey      string `cmd:"" short:"k" help:"The advertiser private key to use for the operation. If not provided, the key saved in the cofinguration file will be used."`
 		NumThreads         int    `cmd:"" short:"n" default:"1" help:"The number of threads to use for the operation. Default to 1, and maximum is 8."`
 	}
 )
+
+func (c *MatchCmd) Help() string {
+	return `
+This operation produces the match rate of this PAIR clean room operation,
+and output the list of decrypted and matched PAIR IDs.
+
+Please be aware that this operation is for demo purposes only for
+resonable data size.
+`
+}
 
 func (c *MatchCmd) Run(cli *CliContext) error {
 	ctx := cli.Context()


### PR DESCRIPTION
Optionally, if the user has computed the interesected triple encrypted PAIR IDs elsewhere, and wants to decrypt the matched IDs, this command can be invoked to do so.

example usage:
```
cat matched.csv | bin/pair decrypt -n24 -v -o decrypted.csv
2024-10-17T16:54:26-04:00 WRN Number of workers is limited to 12 cli=pair
2024-10-17T16:54:30-04:00 DBG ReEncrypt: read 682745 IDs, written 682745 PAIR IDs in 4.253662041s cli=pair
```