### PR TITLE
Only base64 encode PAIR IDs once

### DIFF
--- a/pkg/pair/match.go
+++ b/pkg/pair/match.go
@@ -150,7 +150,6 @@ func (m *matcher) Match(ctx context.Context, numWorkers int, salt, privateKey st
 	if err != nil {
 		return fmt.Errorf("NewPAIRPrivateKey: %w", err)
 	}
-	decrypt := decryptAndBase64EncodeFunc(pk)
 
 	g, ctx := errgroup.WithContext(ctx)
 
@@ -191,7 +190,7 @@ func (m *matcher) Match(ctx context.Context, numWorkers int, salt, privateKey st
 				case <-ctx.Done():
 					return ctx.Err()
 				default:
-					decrypted, err := decrypt(matched)
+					decrypted, err := pk.Decrypt(matched)
 					if err != nil {
 						return err
 					}

--- a/pkg/pair/pair.go
+++ b/pkg/pair/pair.go
@@ -2,7 +2,6 @@ package pair
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -167,18 +166,6 @@ func (p *pairIDReadWriter) Decrypt(ctx context.Context, numWorkers int, salt, pr
 	return runPAIROperation(ctx, p, numWorkers, salt, privateKey, PAIROperationDecrypt)
 }
 
-func decryptAndBase64EncodeFunc(pk *pair.PrivateKey) func(ciphertext []byte) ([]byte, error) {
-	return func(bytes []byte) ([]byte, error) {
-		decrypted, err := pk.Decrypt(bytes)
-		if err != nil {
-			return nil, err
-		}
-		dst := make([]byte, base64.StdEncoding.EncodedLen(len(decrypted)))
-		base64.StdEncoding.Encode(dst, decrypted)
-		return dst, nil
-	}
-}
-
 func runPAIROperation(ctx context.Context, p *pairIDReadWriter, numWorkers int, salt, privateKey string, op PAIROperation) error {
 	// Cancel the context when the operation needs more than an 4 hours
 	ctx, cancel := context.WithTimeout(ctx, maxOperationRunTime)
@@ -235,7 +222,7 @@ func runPAIROperation(ctx context.Context, p *pairIDReadWriter, numWorkers int, 
 					operation.do = pk.ReEncrypt
 					operation.shuffle = true
 				case PAIROperationDecrypt:
-					operation.do = decryptAndBase64EncodeFunc(pk)
+					operation.do = pk.Decrypt
 				default:
 					err := errors.New("invalid operation")
 					errChan <- err


### PR DESCRIPTION
PAIR IDs obtained from `pair.PrivateKey` operations are already base64 encoded.