### PR TITLE
Add threshold checking

### DIFF
--- a/pkg/cmd/cli/pair.go
+++ b/pkg/cmd/cli/pair.go
@@ -69,7 +69,7 @@ func NewPAIRConfig(ctx context.Context, token string, threads int, key string) (
 	}, nil
 }
 
-func (c *pairConfig) hashEncryt(ctx context.Context, input string) error {
+func (c *pairConfig) hashEncryt(ctx context.Context, input string) (err error) {
 	logger := zerolog.Ctx(ctx)
 	logger.Info().Msg("Step 1: Hash and encrypt the advertiser data.")
 
@@ -85,6 +85,10 @@ func (c *pairConfig) hashEncryt(ctx context.Context, input string) error {
 		return fmt.Errorf("bucket.NewBucketCompleter: %w", err)
 	}
 	defer func() {
+		if err != nil {
+			return
+		}
+
 		if err := bucketCompleter.Complete(ctx); err != nil {
 			logger.Error().Err(err).Msg("failed to write .Completed file to bucket")
 			return
@@ -117,10 +121,10 @@ func (c *pairConfig) hashEncryt(ctx context.Context, input string) error {
 
 	logger.Info().Msg("Step 1: Hash and encrypt the advertiser data completed.")
 
-	return nil
+	return
 }
 
-func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string) error {
+func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string) (err error) {
 	logger := zerolog.Ctx(ctx)
 	logger.Info().Msg("Step 2: Re-encrypt the publisher's hashed and encrypted PAIR IDs.")
 
@@ -130,6 +134,10 @@ func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string)
 		return fmt.Errorf("bucket.NewBucketCompleter: %w", err)
 	}
 	defer func() {
+		if err != nil {
+			return
+		}
+
 		if err := bucketCompleter.Complete(ctx); err != nil {
 			logger.Error().Err(err).Msg("failed to write .Completed file to bucket")
 			return
@@ -177,7 +185,7 @@ func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string)
 
 	logger.Info().Msg("Step 2: Re-encrypt the publisher's hashed and encrypted PAIR IDs completed.")
 
-	return nil
+	return
 }
 
 func (c *pairConfig) match(ctx context.Context, outputPath string, publisherPAIRIDsPath string) error {

--- a/pkg/cmd/cli/pair.go
+++ b/pkg/cmd/cli/pair.go
@@ -85,6 +85,8 @@ func (c *pairConfig) hashEncryt(ctx context.Context, input string) (err error) {
 		return fmt.Errorf("bucket.NewBucketCompleter: %w", err)
 	}
 	defer func() {
+		// don't complete the bucket if there was an error to prevent writing
+		// unwanted files.
 		if err != nil {
 			return
 		}
@@ -100,6 +102,8 @@ func (c *pairConfig) hashEncryt(ctx context.Context, input string) (err error) {
 		return fmt.Errorf("bucket.NewBucket: %w", err)
 	}
 	defer func() {
+		// don't close the bucket if there was an error to prevent writing
+		// unwanted files.
 		if err != nil {
 			return
 		}
@@ -138,6 +142,8 @@ func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string)
 		return fmt.Errorf("bucket.NewBucketCompleter: %w", err)
 	}
 	defer func() {
+		// don't complete the bucket if there was an error to prevent writing
+		// unwanted files.
 		if err != nil {
 			return
 		}
@@ -153,6 +159,8 @@ func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string)
 		return fmt.Errorf("bucket.NewBucket: %w", err)
 	}
 	defer func() {
+		// don't close the bucket if there was an error to prevent writing
+		// unwanted files.
 		if err != nil {
 			return
 		}

--- a/pkg/cmd/cli/pair.go
+++ b/pkg/cmd/cli/pair.go
@@ -100,6 +100,10 @@ func (c *pairConfig) hashEncryt(ctx context.Context, input string) (err error) {
 		return fmt.Errorf("bucket.NewBucket: %w", err)
 	}
 	defer func() {
+		if err != nil {
+			return
+		}
+
 		if err := b.Close(); err != nil {
 			logger.Error().Err(err).Msg("failed to close bucket")
 			return
@@ -149,6 +153,10 @@ func (c *pairConfig) reEncrypt(ctx context.Context, publisherPAIRIDsPath string)
 		return fmt.Errorf("bucket.NewBucket: %w", err)
 	}
 	defer func() {
+		if err != nil {
+			return
+		}
+
 		if err := b.Close(); err != nil {
 			logger.Error().Err(err).Msg("failed to close bucket")
 			return


### PR DESCRIPTION
According to the recommendation of the PAIR protocol, cleanrooms with data set size under 1000 IDs should not proceed.
When running a PAIR clean room with a dataset size under threshold, CLI will return an error:
```
opair: error: hashEncryt: pairRW.HashEncrypt: not enough identifiers for a secure PAIR ID match
```