### PR TITLE
Get Full view of cleanroom if it's in FAILED state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gtank/ristretto255 v0.1.2
 	github.com/optable/match v1.4.0
-	github.com/optable/match-api/v2 v2.4.0
+	github.com/optable/match-api/v2 v2.6.0
 	github.com/rs/zerolog v1.33.0
 	gocloud.dev v0.39.0
 	golang.org/x/oauth2 v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/optable/match v1.4.0 h1:kyj1ty6qFIRVFsB6zTJab0RF3Duq9xqPIdld7+4IDa4=
 github.com/optable/match v1.4.0/go.mod h1:l8DT0v6TfmIT53vBbEAp+W0EFAxJ22NIEeJDz0z3WDM=
-github.com/optable/match-api/v2 v2.4.0 h1:OpvjVbc8VQyovVVK9nkBQWlxZK6UVQ3kCAsu0VuSpZY=
-github.com/optable/match-api/v2 v2.4.0/go.mod h1:b4eo6B06BE4goiWwhJ3bNl1BTuMF6hIZdGEhbRgdEkI=
+github.com/optable/match-api/v2 v2.6.0 h1:MHZD5JWjwu7evHong9m3deyHi2hDzk77odMNtG33xbk=
+github.com/optable/match-api/v2 v2.6.0/go.mod h1:b4eo6B06BE4goiWwhJ3bNl1BTuMF6hIZdGEhbRgdEkI=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/cmd/cli/run.go
+++ b/pkg/cmd/cli/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/docker/docker/daemon/logger"
 	v1 "github.com/optable/match-api/v2/gen/optable/external/v1"
 )
 
@@ -67,6 +68,11 @@ func (c *RunCmd) Run(cli *CliContext) error {
 	cleanroom, err := pairCfg.cleanroomClient.GetCleanroom(ctx, false)
 	if err != nil {
 		return fmt.Errorf("GetCleanroom: %w", err)
+	}
+
+	if cleanroom.GetState() != v1.Cleanroom_ACTIVE {
+		logger.Info().Msgf("The cleanroom is an unexpected state: %s. See more details with the cleanroom get command.", cleanroom.GetState())
+		return nil
 	}
 
 	// Get the state of the publisher and advertiser

--- a/pkg/cmd/cli/run.go
+++ b/pkg/cmd/cli/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/daemon/logger"
 	v1 "github.com/optable/match-api/v2/gen/optable/external/v1"
 )
 
@@ -71,7 +70,7 @@ func (c *RunCmd) Run(cli *CliContext) error {
 	}
 
 	if cleanroom.GetState() != v1.Cleanroom_ACTIVE {
-		logger.Info().Msgf("The cleanroom is an unexpected state: %s. See more details with the cleanroom get command.", cleanroom.GetState())
+		fmt.Printf("The cleanroom is an unexpected state: %s. See more details with the cleanroom get command.\n", cleanroom.GetState())
 		return nil
 	}
 

--- a/pkg/internal/client.go
+++ b/pkg/internal/client.go
@@ -55,7 +55,17 @@ func (c *CleanroomClient) GetCleanroom(ctx context.Context, sensitive bool) (*v1
 		req.View = v1.GetCleanroomRequest_SENSITIVE
 	}
 
-	return c.do(ctx, req)
+	clr, err := c.do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if clr.GetState() == v1.Cleanroom_FAILED {
+		req.View = v1.GetCleanroomRequest_FULL
+		return c.do(ctx, req)
+	}
+
+	return clr, nil
 }
 
 func (c *CleanroomClient) RefreshToken(ctx context.Context) (*v1.Cleanroom, error) {


### PR DESCRIPTION
When the clean room is in the FAILED state, the response of `Get` should return the full view of the failed clean room, instead of displaying no longer valid clean room GCS token.